### PR TITLE
Chore/multiple secrets fetch fix

### DIFF
--- a/Sources/Tapp/Core/Tapp+Adjust.swift
+++ b/Sources/Tapp/Core/Tapp+Adjust.swift
@@ -12,48 +12,89 @@ extension Tapp {
 
     @objc
     public static func getAdjustAttribution(completion: @escaping (AdjustAttribution?) -> Void) {
-        single.dependencies.services.adjustService.getAttribution(completion: completion)
+        single.getAdjustAttribution(completion: completion)
+    }
+
+    func getAdjustAttribution(completion: @escaping (AdjustAttribution?) -> Void) {
+        dependencies.services.adjustService.getAttribution(completion: completion)
     }
 
     @objc
     public static func adjustGdprForgetMe() {
-        single.dependencies.services.adjustService.gdprForgetMe()
+        single.adjustGdprForgetMe()
+    }
+
+    func adjustGdprForgetMe() {
+        dependencies.services.adjustService.gdprForgetMe()
     }
 
     @objc
     public static func adjustTrackThirdPartySharing(isEnabled: Bool) {
-        single.dependencies.services.adjustService.trackThirdPartySharing(isEnabled: isEnabled)
+        single.adjustTrackThirdPartySharing(isEnabled: isEnabled)
+    }
+
+    func adjustTrackThirdPartySharing(isEnabled: Bool) {
+        dependencies.services.adjustService.trackThirdPartySharing(isEnabled: isEnabled)
     }
 
     @objc
     public static func adjustTrackAdRevenue(source: String,
                                      revenue: Double,
                                      currency: String) {
-        single.dependencies.services.adjustService.trackAdRevenue(
-            source: source, revenue: revenue, currency: currency)
+        single.adjustTrackAdRevenue(source: source,
+                                    revenue: revenue,
+                                    currency: currency)
+    }
+
+    func adjustTrackAdRevenue(source: String,
+                                     revenue: Double,
+                                     currency: String) {
+        dependencies.services.adjustService.trackAdRevenue(source: source,
+                                                           revenue: revenue,
+                                                           currency: currency)
     }
 
     @objc
     public static func adjustVerifyAppStorePurchase(transactionId: String,
                                              productId: String,
                                                     completion: @escaping (AdjustPurchaseVerificationResult) -> Void) {
-        single.dependencies.services.adjustService.verifyAppStorePurchase(transactionId: transactionId,
+        single.adjustVerifyAppStorePurchase(transactionId: transactionId,
+                                            productId: productId,
+                                            completion: completion)
+    }
+
+    func adjustVerifyAppStorePurchase(transactionId: String,
+                                             productId: String,
+                                                    completion: @escaping (AdjustPurchaseVerificationResult) -> Void) {
+        dependencies.services.adjustService.verifyAppStorePurchase(transactionId: transactionId,
                                                       productId: productId,
                                                       completion: completion)
     }
 
     @objc
     public static func adjustSetPushToken(token: String) {
-        single.dependencies.services.adjustService.setPushToken(token)
+        single.adjustSetPushToken(token: token)
+    }
+
+    func adjustSetPushToken(token: String) {
+        dependencies.services.adjustService.setPushToken(token)
     }
 
     @objc
     public static func adjustGetAdid(completion: @escaping (String?) -> Void) {
-        single.dependencies.services.adjustService.getAdid(completion: completion)
+        single.adjustGetAdid(completion: completion)
+    }
+
+    func adjustGetAdid(completion: @escaping (String?) -> Void) {
+        dependencies.services.adjustService.getAdid(completion: completion)
     }
 
     @objc
     public static func adjustGetIdfa(completion: @escaping (String?) -> Void) {
-        single.dependencies.services.adjustService.getIdfa(completion: completion)
+        single.adjustGetIdfa(completion: completion)
+    }
+
+    func adjustGetIdfa(completion: @escaping (String?) -> Void) {
+        dependencies.services.adjustService.getIdfa(completion: completion)
     }
 }

--- a/Sources/Tapp/Models/AffiliateURLConfiguration.swift
+++ b/Sources/Tapp/Models/AffiliateURLConfiguration.swift
@@ -12,7 +12,7 @@ public final class AffiliateURLConfiguration: NSObject {
         influencer: String,
         adgroup: String? = nil,
         creative: String? = nil,
-        data: [String: String]?
+        data: [String: String]? = nil
     ) {
         self.influencer = influencer
         self.adgroup = adgroup

--- a/Sources/Tapp/Services/Affiliate/Tapp/AffiliateURL.swift
+++ b/Sources/Tapp/Services/Affiliate/Tapp/AffiliateURL.swift
@@ -70,6 +70,10 @@ public final class GeneratedURLResponse: NSObject, Codable {
     @objc
     public let url: URL
 
+    init(url: URL) {
+        self.url = url
+    }
+
     enum CodingKeys: String, CodingKey {
         case url = "influencer_url"
     }

--- a/Sources/Tapp/Services/Affiliate/Tapp/TappAffiliateService.swift
+++ b/Sources/Tapp/Services/Affiliate/Tapp/TappAffiliateService.swift
@@ -84,20 +84,20 @@ final class TappAffiliateService: TappAffiliateServiceProtocol {
                    completion: completion)
     }
 
-    func secrets(affiliate: Affiliate, completion: SecretsCompletion?) {
+    func secrets(affiliate: Affiliate, completion: SecretsCompletion?) -> URLSessionDataTaskProtocol? {
         guard let config = keychainHelper.config, let bundleID = config.bundleID else {
             completion?(Result.failure(ServiceError.invalidData))
-            return
+            return nil
         }
         let secretsRequest = SecretsRequest(tappToken: config.tappToken, bundleID: bundleID, mmp: affiliate.rawValue)
         let endpoint = TappEndpoint.secrets(secretsRequest)
 
         guard let request = endpoint.request else {
             completion?(Result.failure(ServiceError.invalidRequest))
-            return
+            return nil
         }
 
-        networkClient.executeAuthenticated(request: request) { result in
+        return networkClient.executeAuthenticated(request: request) { result in
             switch result {
             case .success(let data):
                 let decoder = JSONDecoder()

--- a/Sources/Tapp/Services/Affiliate/Tapp/TappSpecificService.swift
+++ b/Sources/Tapp/Services/Affiliate/Tapp/TappSpecificService.swift
@@ -11,5 +11,5 @@ protocol TappServiceProtocol {
     func url(request: GenerateURLRequest, completion: GenerateURLCompletion?)
     func handleImpression(url: URL, completion: VoidCompletion?)
     func sendTappEvent(event: TappEvent, completion: VoidCompletion?)
-    func secrets(affiliate: Affiliate, completion: SecretsCompletion?)
+    func secrets(affiliate: Affiliate, completion: SecretsCompletion?) -> URLSessionDataTaskProtocol?
 }

--- a/Tests/TappTests/Mocks/AdjustServiceProtocolMock.swift
+++ b/Tests/TappTests/Mocks/AdjustServiceProtocolMock.swift
@@ -1,0 +1,47 @@
+import Foundation
+@testable import Tapp
+
+protocol AdjustAffiliateServiceProtocol: AffiliateServiceProtocol, AdjustServiceProtocol {}
+
+final class AdjustServiceProtocolMock: AffiliateServiceProtocolMock, AdjustAffiliateServiceProtocol {
+
+    var getAttributionCalled: Bool = false
+    func getAttribution(completion: @escaping (AdjustAttribution?) -> Void) {
+        getAttributionCalled = true
+    }
+
+    var gdprForgetMeCalled: Bool = false
+    func gdprForgetMe() {
+        gdprForgetMeCalled = true
+    }
+
+    var trackThirdPartySharingCalled: Bool = false
+    func trackThirdPartySharing(isEnabled: Bool) {
+        trackThirdPartySharingCalled = true
+    }
+
+    var trackAdRevenueCalled: Bool = false
+    func trackAdRevenue(source: String, revenue: Double, currency: String) {
+        trackAdRevenueCalled = true
+    }
+
+    var verifyAppStorePurchaseCalled: Bool = false
+    func verifyAppStorePurchase(transactionId: String, productId: String, completion: @escaping (AdjustPurchaseVerificationResult) -> Void) {
+        verifyAppStorePurchaseCalled = true
+    }
+
+    var setPushTokenCalled: Bool = false
+    func setPushToken(_ token: String) {
+        setPushTokenCalled = true
+    }
+
+    var getAdidCalled: Bool = false
+    func getAdid(completion: @escaping (String?) -> Void) {
+        getAdidCalled = true
+    }
+
+    var getIdfaCalled: Bool = false
+    func getIdfa(completion: @escaping (String?) -> Void) {
+        getIdfaCalled = true
+    }
+}

--- a/Tests/TappTests/Mocks/AffiliateServiceProtocolMock.swift
+++ b/Tests/TappTests/Mocks/AffiliateServiceProtocolMock.swift
@@ -1,0 +1,26 @@
+import Foundation
+@testable import Tapp
+
+class AffiliateServiceProtocolMock: NSObject, AffiliateServiceProtocol {
+    var isInitialized: Bool = false
+    var initializeCompletion: VoidCompletion?
+    var initializeError: Error?
+    func initialize(environment: Environment,
+                    completion: VoidCompletion?) {
+        if let initializeError {
+            completion?(Result.failure(initializeError))
+        } else {
+            completion?(Result.success(()))
+        }
+    }
+
+    var handleCallbackCalled: Bool = false
+    func handleCallback(with url: String) {
+        handleCallbackCalled = true
+    }
+
+    var handleEventCalled: Bool = false
+    func handleEvent(eventId: String, authToken: String?) {
+        handleEventCalled = true
+    }
+}

--- a/Tests/TappTests/Mocks/AppsFlyerAffiliateServiceProtocolMock.swift
+++ b/Tests/TappTests/Mocks/AppsFlyerAffiliateServiceProtocolMock.swift
@@ -1,0 +1,4 @@
+import Foundation
+@testable import Tapp
+
+final class AppsFlyerAffiliateServiceProtocolMock: AffiliateServiceProtocolMock, AppsFlyerAffiliateServiceProtocol {}

--- a/Tests/TappTests/Mocks/Mocks.swift
+++ b/Tests/TappTests/Mocks/Mocks.swift
@@ -53,8 +53,10 @@ final class URLSessionMock: URLSessionProtocol {
 final class KeychainHelperProtocolMock: KeychainHelperProtocol {
 
     var saveCalled: Bool = false
+    var savedConfig: TappConfiguration?
     func save(config: TappConfiguration) {
         saveCalled = true
+        savedConfig = config
     }
     
     var config: TappConfiguration?
@@ -122,3 +124,54 @@ final class AdjustInterfaceProtocolMock: AdjustInterfaceProtocol {
         getIdfaCalled = true
     }
 }
+
+final class NetworkClientProtocolMock: NetworkClientProtocol {
+
+    var executeCompletion: NetworkServiceCompletion?
+    var executeDataTask: URLSessionDataTaskProtocol?
+    var executeData: Data?
+    var executeError: Error?
+    @discardableResult func execute(request: URLRequest, completion: NetworkServiceCompletion?) -> URLSessionDataTaskProtocol? {
+        if let executeError {
+            completion?(Result.failure(executeError))
+        } else if let executeData {
+            completion?(Result.success(executeData))
+        }
+        return executeDataTask
+    }
+
+    var executeAuthenticatedCompletion: NetworkServiceCompletion?
+    var executeAuthenticatedDataTask: URLSessionDataTaskProtocol?
+    var executeAuthenticatedData: Data?
+    var executeAuthenticatedError: Error?
+    @discardableResult func executeAuthenticated(request: URLRequest, completion: NetworkServiceCompletion?) -> URLSessionDataTaskProtocol? {
+
+        if let executeAuthenticatedError {
+            completion?(Result.failure(executeAuthenticatedError))
+
+        } else if let executeAuthenticatedData {
+            completion?(Result.success(executeAuthenticatedData))
+        }
+
+        return executeAuthenticatedDataTask
+    }
+}
+
+final class DependenciesMock {
+    let keychainHelper: KeychainHelperProtocolMock = .init()
+    let networkClient: NetworkClientProtocolMock = .init()
+    let tappAffiliateService: TappAffiliateServiceProtocolMock = .init()
+    let adjustAffiliateService: AdjustServiceProtocolMock = .init()
+    let appsFlyerAffiliateService: AppsFlyerAffiliateServiceProtocolMock = .init()
+    let services: Services
+    let dependencies: Dependencies
+
+    init() {
+        let services = Services(tappService: tappAffiliateService, adjustService: adjustAffiliateService, appsFlyerService: appsFlyerAffiliateService)
+        self.services = services
+        self.dependencies = Dependencies(keychainHelper: keychainHelper,
+                                         networkClient: networkClient,
+                                         services: services)
+    }
+}
+

--- a/Tests/TappTests/Mocks/TappAffiliateServiceProtocolMock.swift
+++ b/Tests/TappTests/Mocks/TappAffiliateServiceProtocolMock.swift
@@ -1,0 +1,61 @@
+import Foundation
+@testable import Tapp
+
+final class TappAffiliateServiceProtocolMock: AffiliateServiceProtocolMock, TappAffiliateServiceProtocol {
+    var urlResponse: GeneratedURLResponse? {
+        didSet {
+            if let urlResponse {
+                completion?(Result.success(urlResponse))
+            }
+        }
+    }
+    var urlError: Error? {
+        didSet {
+            if let urlError {
+                completion?(Result.failure(urlError))
+            }
+        }
+    }
+    var completion: GenerateURLCompletion?
+    func url(request: GenerateURLRequest, completion: GenerateURLCompletion?) {
+        self.completion = completion
+    }
+
+    var handleImpressionError: Error?
+    func handleImpression(url: URL, completion: VoidCompletion?) {
+        if let handleImpressionError {
+            completion?(Result.failure(handleImpressionError))
+        } else {
+            completion?(Result.success(()))
+        }
+    }
+
+    var sendTappEventError: Error?
+    func sendTappEvent(event: TappEvent, completion: VoidCompletion?) {
+        if let sendTappEventError {
+            completion?(Result.failure(sendTappEventError))
+        } else {
+            completion?(Result.success(()))
+        }
+    }
+
+    var secretsTask: URLSessionDataTaskProtocol?
+    var secretsResponse: SecretsResponse? {
+        didSet {
+            if let secretsError {
+                secretsCompletion?(Result.failure(secretsError))
+            } else if let secretsResponse {
+                secretsCompletion?(Result.success(secretsResponse))
+            }
+        }
+    }
+    var secretsError: Error?
+    var secretsCalledCount: Int = 0
+    var secretsCompletion: SecretsCompletion?
+    func secrets(affiliate: Affiliate, completion: SecretsCompletion?) -> URLSessionDataTaskProtocol? {
+        secretsCalledCount += 1
+        secretsCompletion = completion
+
+        return secretsTask
+    }
+}

--- a/Tests/TappTests/Mocks/Task+Helpers.swift
+++ b/Tests/TappTests/Mocks/Task+Helpers.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+extension Task where Success == Never, Failure == Never {
+    private static let oneSecondInNanoseconds: UInt64 = 1_000_000_000
+    private static let oneMillisecondInNanoseconds: UInt64 = 1_000_000
+
+    static func sleep(seconds: UInt64) async throws {
+        if #available(iOS 16, *) {
+            try await sleep(for: .seconds(seconds))
+        } else {
+            try await sleep(nanoseconds: oneSecondInNanoseconds * seconds)
+        }
+    }
+
+    static func sleep(milliseconds: UInt64) async throws {
+        if #available(iOS 16, *) {
+            try await sleep(for: .milliseconds(milliseconds))
+        } else {
+            try await sleep(nanoseconds: oneMillisecondInNanoseconds * milliseconds)
+        }
+    }
+}

--- a/Tests/TappTests/TappTests+Adjust.swift
+++ b/Tests/TappTests/TappTests+Adjust.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Tapp
+
+extension TappTests {
+    func testGetAdjustAttribution() {
+        sut.getAdjustAttribution { _ in }
+        XCTAssertTrue(dependenciesMock.adjustAffiliateService.getAttributionCalled)
+    }
+
+    func testAdjustGdprForgetMe() {
+        sut.adjustGdprForgetMe()
+        XCTAssertTrue(dependenciesMock.adjustAffiliateService.gdprForgetMeCalled)
+    }
+
+    func testAdjustTrackThirdPartySharing() {
+        sut.adjustTrackThirdPartySharing(isEnabled: false)
+        XCTAssertTrue(dependenciesMock.adjustAffiliateService.trackThirdPartySharingCalled)
+    }
+
+    func testAdjustTrackAdRevenue() {
+        sut.adjustTrackAdRevenue(source: .empty,
+                                 revenue: 0,
+                                 currency: .empty)
+        XCTAssertTrue(dependenciesMock.adjustAffiliateService.trackAdRevenueCalled)
+    }
+
+    func testAdjustVerifyAppStorePurchase() {
+        sut.adjustVerifyAppStorePurchase(transactionId: .empty, productId: .empty) { _ in }
+        XCTAssertTrue(dependenciesMock.adjustAffiliateService.verifyAppStorePurchaseCalled)
+    }
+
+    func testAdjustSetPushToken() {
+        sut.adjustSetPushToken(token: .empty)
+        XCTAssertTrue(dependenciesMock.adjustAffiliateService.setPushTokenCalled)
+    }
+
+    func testAdjustGetAdid() {
+        sut.adjustGetAdid { _ in }
+        XCTAssertTrue(dependenciesMock.adjustAffiliateService.getAdidCalled)
+    }
+
+    func testAdjustGetIdfa() {
+        sut.adjustGetIdfa { _ in }
+        XCTAssertTrue(dependenciesMock.adjustAffiliateService.getIdfaCalled)
+    }
+}
+
+private extension String {
+    static var empty: String {
+        return ""
+    }
+}

--- a/Tests/TappTests/TappTests.swift
+++ b/Tests/TappTests/TappTests.swift
@@ -2,5 +2,139 @@ import XCTest
 @testable import Tapp
 
 final class TappTests: XCTestCase {
-    
+    var dependenciesMock: DependenciesMock!
+    var sut: Tapp!
+
+    override func setUp() {
+        super.setUp()
+        dependenciesMock = .init()
+        sut = Tapp(dependencies: dependenciesMock.dependencies)
+    }
+
+    func testInitializeWithoutConfig() {
+        sut.initializeEngine { result in
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                guard let error = error as? TappError else {
+                    XCTFail()
+                    return
+                }
+                switch error {
+                case .missingConfiguration:
+                    break
+                default:
+                    XCTFail()
+                }
+            }
+        }
+    }
+
+    func testMultipleInitializeEngineCalls() async throws {
+        dependenciesMock.keychainHelper.config = testConfiguration
+        dependenciesMock.tappAffiliateService.secretsTask = URLSessionDataTaskProtocolMock(identifier: 1)
+
+        let expectation1 = self.expectation(description: "initialization1")
+        sut.initializeEngine { result in
+            expectation1.fulfill()
+        }
+
+        let expectation2 = self.expectation(description: "initialization2")
+
+        sut.initializeEngine { result in
+            expectation2.fulfill()
+        }
+
+        try await Task.sleep(milliseconds: 100)
+
+        dependenciesMock.tappAffiliateService.secretsResponse = SecretsResponse(secret: "123")
+
+        await fulfillment(of: [expectation1, expectation2], timeout: 0.5)
+
+        XCTAssertEqual(dependenciesMock.tappAffiliateService.secretsCalledCount, 1)
+    }
+
+    func testAppWillOpen() async throws {
+        dependenciesMock.keychainHelper.config = testConfiguration
+        dependenciesMock.tappAffiliateService.secretsTask = URLSessionDataTaskProtocolMock(identifier: 1)
+        XCTAssertEqual(dependenciesMock.keychainHelper.config?.hasProcessedReferralEngine, false)
+
+        let url = try XCTUnwrap(URL(string: "https://tapp.so"))
+
+        let expectation = self.expectation(description: "appWillOpen")
+        sut.appWillOpen(url, authToken: "authToken") { result in
+            expectation.fulfill()
+        }
+
+        try await Task.sleep(milliseconds: 50)
+
+        dependenciesMock.tappAffiliateService.secretsResponse = SecretsResponse(secret: "123")
+
+        await fulfillment(of: [expectation], timeout: 0.5)
+        XCTAssertEqual(dependenciesMock.keychainHelper.config?.originURL, url)
+        XCTAssertEqual(dependenciesMock.keychainHelper.config?.hasProcessedReferralEngine, true)
+        XCTAssertTrue(dependenciesMock.adjustAffiliateService.handleCallbackCalled)
+    }
+
+    func testInitializeAndAppWillOpenSimultaneously() async throws {
+        dependenciesMock.keychainHelper.config = testConfiguration
+        dependenciesMock.tappAffiliateService.secretsTask = URLSessionDataTaskProtocolMock(identifier: 1)
+
+        let expectation1 = self.expectation(description: "initialization1")
+        sut.initializeEngine { result in
+            expectation1.fulfill()
+        }
+
+        let url = try XCTUnwrap(URL(string: "https://tapp.so"))
+
+        let expectation2 = self.expectation(description: "appWillOpen")
+        sut.appWillOpen(url, authToken: "authToken") { result in
+            expectation2.fulfill()
+        }
+
+        try await Task.sleep(milliseconds: 50)
+
+        dependenciesMock.tappAffiliateService.secretsResponse = SecretsResponse(secret: "123")
+
+        await fulfillment(of: [expectation1, expectation2], timeout: 0.5)
+
+        XCTAssertEqual(dependenciesMock.tappAffiliateService.secretsCalledCount, 1)
+        XCTAssertEqual(dependenciesMock.keychainHelper.config?.originURL, url)
+        XCTAssertEqual(dependenciesMock.keychainHelper.config?.hasProcessedReferralEngine, true)
+        XCTAssertTrue(dependenciesMock.adjustAffiliateService.handleCallbackCalled)
+    }
+
+    func testFetchURL() async throws {
+        dependenciesMock.keychainHelper.config = testConfiguration
+        dependenciesMock.tappAffiliateService.secretsTask = URLSessionDataTaskProtocolMock(identifier: 1)
+        let expectation = self.expectation(description: "urlFetch")
+        let configuration = AffiliateURLConfiguration(influencer: "someID")
+        let url = try XCTUnwrap(URL(string: "https://tapp.so"))
+        sut.url(config: configuration) { result in
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response.url, url)
+            case .failure:
+                XCTFail()
+            }
+            expectation.fulfill()
+        }
+
+        try await Task.sleep(milliseconds: 50)
+        
+        dependenciesMock.tappAffiliateService.secretsResponse = SecretsResponse(secret: "123")
+        dependenciesMock.tappAffiliateService.urlResponse = GeneratedURLResponse(url: url)
+
+        await fulfillment(of: [expectation], timeout: 0.5)
+    }
+}
+
+private extension TappTests {
+    var testConfiguration: TappConfiguration {
+        return TappConfiguration(authToken: "authToken",
+                                 env: .sandbox,
+                                 tappToken: "tappToken",
+                                 affiliate: .adjust)
+    }
 }

--- a/Tests/TappTests/TappTests.swift
+++ b/Tests/TappTests/TappTests.swift
@@ -1,1 +1,6 @@
+import XCTest
+@testable import Tapp
 
+final class TappTests: XCTestCase {
+    
+}


### PR DESCRIPTION
Fixes concurrency for Secrets fetch when for instance start and appWillOpen will be getting called on the client apps lifecycle.

Also added a bunch of unit tests